### PR TITLE
Support @generator for tags of polymorphic variants

### DIFF
--- a/test/test.ml
+++ b/test/test.ml
@@ -91,6 +91,12 @@ type stdord =
   | Nonempty of hlifd list
 [@@deriving crowbar { nonempty = true }]
 
+type poly_variant = [
+  | `A of int [@generator Crowbar.const (`A 0)]
+]
+[@@deriving crowbar]
+
+
 let () =
   Crowbar.(add_test ~name:"everything is awesome"
              [foo_to_crowbar; bar_to_crowbar; quux_to_crowbar]
@@ -103,3 +109,7 @@ let () =
              [stdord_to_crowbar] (function
                  | Nonempty [] -> Crowbar.fail "ugh"
                  | _ -> ()));
+  Crowbar.(add_test ~name:"polymorphic variants"
+             [poly_variant_to_crowbar] (function
+                 | `A 0 -> ()
+                 | _ -> Crowbar.fail "bah"));


### PR DESCRIPTION
Thanks for creating this ppx, it's most helpful! 💯 

I wanted to use the `@generator` annotation with polymorphic variants, but it appeared to be ignored.

Example:

```ocaml
type poly_variant = [
  | `A of int [@generator Crowbar.const (`A 0)]
]
[@@deriving crowbar]
```

Output without these changes:

```ocaml
let rec (poly_variant_to_crowbar : poly_variant Crowbar.gen Lazy.t) =
  ((let open! Ppx_deriving_runtime in
      lazy
        (Crowbar.choose
           (Crowbar.(::)
              ((let open Crowbar in map [Crowbar.int] (fun a -> `A a)),
                Crowbar.[]))))
  [@ocaml.warning "-A"])
let (lazy poly_variant_to_crowbar) = poly_variant_to_crowbar
```

After looking into it briefly, I came up with the proposed changes -- it's likely not the most clever.

Output with these changes:

```ocaml
let rec poly_variant_to_crowbar : poly_variant Crowbar.gen Lazy.t =
  let __0 () = Crowbar.const (`A 0) in
  ((let open! Ppx_deriving_runtime in
      lazy (Crowbar.choose (Crowbar.(::) ((__0 ()), Crowbar.[]))))
    [@ocaml.warning "-A"])
let (lazy poly_variant_to_crowbar) = poly_variant_to_crowbar
```