### PR TITLE
fix build system for ppx_deriving.4.3

### DIFF
--- a/_tags
+++ b/_tags
@@ -2,4 +2,5 @@ true: warn(@5@8@10@11@12@14@23@24@26@29@40), bin_annot, safe_string
 
 "src": include
 <src/*.{ml,mli,byte,native}>: package(ppx_tools.metaquot), package(ppx_deriving.api), package(result), package(crowbar), package(compiler-libs)
+<src/ppx_deriving_crowbar_runtime.*>: package(ppx_deriving.runtime)
 true: linkall


### PR DESCRIPTION
ppx_deriving plugins should generally depend on the `ppx_deriving.api` package (ppx_deriving_crowbar does that right), but their runtime module should also depend on `ppx_deriving.runtime` (ppx_deriving_crowbar_runtime does not). With existing releases of ppx_deriving (<= 4.2.1), forgetting a `ppx_deriving.runtime` dependency does not result in a build failure, because `ppx_deriving.api` and `ppx_deriving.runtime` install their object files in the same directory, so the `ppx_deriving.api` dependency is enough to find the runtime. With the new version ppx_deriving.4.3, to be released (very soon!), this omission will result in a build failure.

This PR fixes the build failure with ppx_deriving.4.3, but remains compatible with older releases of ppx_deriving.